### PR TITLE
Add CI workflow for Go tests

### DIFF
--- a/.github/workflows/go_tests.yml
+++ b/.github/workflows/go_tests.yml
@@ -1,0 +1,51 @@
+name: Go_Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        go-version: [1.23.4]
+        os: [ubuntu-latest]
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+
+    - name: Restore cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/go/pkg/mod
+          ~/.cache/go-build
+        key: ${{ runner.os }}-go-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-${{ matrix.go-version }}-
+
+    - name: Install dependencies
+      run: go mod download
+
+    - name: Run tests
+      run: go test ./... -v
+
+    - name: Save cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/go/pkg/mod
+          ~/.cache/go-build
+        key: ${{ runner.os }}-go-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}


### PR DESCRIPTION
Add a GitHub Actions workflow for running Go tests.

* Create a new directory `.github/workflows`.
* Add a new file `go_tests.yml` in the `.github/workflows` directory.
* Define a GitHub Actions workflow named `Go_Tests` to run Go tests on every push and pull request to the `main` branch.
* Use `actions/checkout@v2` to check out the code.
* Use `actions/setup-go@v2` to set up Go with version `1.23.4`.
* Use `actions/cache@v2` to cache Go module dependencies.
* Install dependencies using `go mod download`.
* Run tests using `go test ./... -v`.
* Save cache using `actions/cache@v2`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Warashi/lispish/pull/2?shareId=c6232d66-9d51-4c59-8793-6f5bad0b6f82).