### PR TITLE
Remove unused import statement in lexer

### DIFF
--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -2,7 +2,6 @@ package lexer
 
 import (
 	"fmt"
-	"strings"
 	"unicode"
 )
 


### PR DESCRIPTION
Remove the unused import statement for the `strings` package in `lexer/lexer.go`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Warashi/lispish/pull/3?shareId=fcee24e6-4873-41fa-8127-5286d8aabf8f).