### PR TITLE
Fix syntax error in lexer.go

### DIFF
--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -82,7 +82,7 @@ func (l *Lexer) NextToken() (Token, error) {
 		} else if isDigit(l.ch) {
 			return l.readNumber()
 		} else {
-			return Token{}, fmt.Errorf("invalid character '%c' at line %d, column %d", l.ch, l.line, l.column}
+			return Token{}, fmt.Errorf("invalid character '%c' at line %d, column %d", l.ch, l.line, l.column)
 		}
 	}
 


### PR DESCRIPTION
Fix syntax error in `lexer/lexer.go` at line 85.

* Add missing closing parenthesis in `NextToken` function at line 85.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Warashi/lispish/pull/7?shareId=0034564a-1a13-4a7d-9442-456f1aa4bc4d).