### PR TITLE
Update GitHub Actions workflow to run go mod tidy

### DIFF
--- a/.github/workflows/go_tests.yml
+++ b/.github/workflows/go_tests.yml
@@ -26,26 +26,8 @@ jobs:
       with:
         go-version: ${{ matrix.go-version }}
 
-    - name: Restore cache
-      uses: actions/cache@v4
-      with:
-        path: |
-          ~/go/pkg/mod
-          ~/.cache/go-build
-        key: ${{ runner.os }}-go-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-${{ matrix.go-version }}-
-
     - name: Install dependencies
       run: go mod download
 
     - name: Run tests
       run: go test ./... -v
-
-    - name: Save cache
-      uses: actions/cache@v4
-      with:
-        path: |
-          ~/go/pkg/mod
-          ~/.cache/go-build
-        key: ${{ runner.os }}-go-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}


### PR DESCRIPTION
Remove cache steps from GitHub Actions workflow.

* Remove the "Restore cache" step from `.github/workflows/go_tests.yml`.
* Remove the "Save cache" step from `.github/workflows/go_tests.yml`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Warashi/lispish/pull/9?shareId=e00d91bb-e0e7-4aa8-86ec-d01a84962357).