### PR TITLE
Fix lexer to handle whitespace within comments

### DIFF
--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -94,12 +94,20 @@ func (l *Lexer) NextToken() Token {
 
 		// セミコロン ';' で始まる場合、コメント行として改行まで読み飛ばす
 		if text == ";" {
+			// Save the current whitespace flag
+			originalWhitespace := l.s.Whitespace
+			// Include all whitespace characters during comment processing
+			l.s.Whitespace = 0
+
 			for {
 				tok = l.s.Scan()
 				if tok == '\n' || tok == scanner.EOF {
 					break
 				}
 			}
+
+			// Restore the original whitespace flag
+			l.s.Whitespace = originalWhitespace
 			continue
 		}
 

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -11,6 +11,8 @@ func TestLexer(t *testing.T) {
 (define (square x)
   (* x x))
 '(1 2 "three" 4.0)
+; コメント中のホワイトスペースを含む
+; コメント中の	タブを含む
 `
 
 	lexer := NewLexer(strings.NewReader(input))


### PR DESCRIPTION
Modify the lexer to correctly handle whitespace within comments by changing the scanner's whitespace flag and restoring it after exiting the comment.

* **lexer/lexer.go**
  - Save the current whitespace flag before processing comments.
  - Set the whitespace flag to include all whitespace characters during comment processing.
  - Restore the original whitespace flag after the comment ends.

* **lexer/lexer_test.go**
  - Add test cases for comments with whitespace and tabs to ensure correct handling.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Warashi/lispish/pull/11?shareId=613dfc5a-4f59-4267-b29f-c23ad9a7f36b).