### PR TITLE
Add comment token to lexer

### DIFF
--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -18,6 +18,7 @@ const (
 	TokenIdentifier  // 識別子
 	TokenNumber      // 数値（整数・浮動小数点）
 	TokenString      // 文字列リテラル
+	TokenComment     // コメント
 )
 
 // String は TokenType の文字列表現を返します。
@@ -37,6 +38,8 @@ func (t TokenType) String() string {
 		return "Number"
 	case TokenString:
 		return "String"
+	case TokenComment:
+		return "Comment"
 	default:
 		return "Unknown"
 	}
@@ -99,16 +102,18 @@ func (l *Lexer) NextToken() Token {
 			// Include all whitespace characters during comment processing
 			l.s.Whitespace = 0
 
+			commentText := ";"
 			for {
 				tok = l.s.Scan()
 				if tok == '\n' || tok == scanner.EOF {
 					break
 				}
+				commentText += l.s.TokenText()
 			}
 
 			// Restore the original whitespace flag
 			l.s.Whitespace = originalWhitespace
-			continue
+			return Token{Type: TokenComment, Literal: commentText}
 		}
 
 		switch tok {

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -19,6 +19,7 @@ func TestLexer(t *testing.T) {
 
 	// 期待するトークン列
 	expectedTokens := []Token{
+		{Type: TokenComment, Literal: "; コメント行をスキップする"},
 		{Type: TokenLParen, Literal: "("},
 		{Type: TokenIdentifier, Literal: "define"},
 		{Type: TokenLParen, Literal: "("},
@@ -38,6 +39,8 @@ func TestLexer(t *testing.T) {
 		{Type: TokenString, Literal: "three"},
 		{Type: TokenNumber, Literal: "4.0"},
 		{Type: TokenRParen, Literal: ")"},
+		{Type: TokenComment, Literal: "; コメント中のホワイトスペースを含む"},
+		{Type: TokenComment, Literal: "; コメント中の	タブを含む"},
 		{Type: TokenEOF, Literal: ""},
 	}
 


### PR DESCRIPTION
Add support for comment tokens in the lexer.

* Add a new token type `TokenComment` to the `TokenType` enum in `lexer/lexer.go`.
* Modify the `NextToken` function in `lexer/lexer.go` to return `TokenComment` tokens for comments instead of skipping them.
* Update the `String` method in `lexer/lexer.go` to include `TokenComment` in the switch statement.
* Add test cases in `lexer/lexer_test.go` to verify the correct tokenization of comments.
* Update the `expectedTokens` slice in `lexer/lexer_test.go` to include `TokenComment` tokens for comments.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Warashi/lispish/pull/12?shareId=caeb3548-7575-40ce-bf8c-871f3a38f3d6).