### PR TITLE
Remove integration_test.go

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repository contains a lexer implementation for the Scheme programming langu
 - Handles numeric literals in different formats.
 - Provides detailed error messages with line number, column number, and input snippet.
 - Categorizes errors into different types: syntax errors, invalid character errors, and unexpected end of input errors.
-- Includes unit tests and integration tests to ensure correctness.
+- Includes unit tests to ensure correctness.
 
 ### Usage
 
@@ -34,12 +34,6 @@ To use the lexer, follow these steps:
 
    ```sh
    go test ./lexer -v
-   ```
-
-4. Run the integration tests:
-
-   ```sh
-   go test ./lexer -v -run Integration
    ```
 
 ### Example

--- a/lexer/integration_test.go
+++ b/lexer/integration_test.go
@@ -1,1 +1,0 @@
-package lexer


### PR DESCRIPTION
Remove integration tests and update documentation.

* **README.md**
  - Remove the section about running integration tests.
  - Update the example usage to remove the integration test reference.
  - Remove the mention of integration tests in the feature list.

* **lexer/integration_test.go**
  - Delete the file.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Warashi/lispish/pull/13?shareId=d1443827-54dd-48bc-a6f5-3198b63a19b0).