### PR TITLE
Distinguish between integers and floating-point numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository contains a lexer implementation for the Scheme programming langu
 
 - Tokenizes Scheme code into various token types: Identifiers, Keywords, Literals, Operators, Delimiters, and Comments.
 - Handles string literals, including escape sequences.
-- Handles numeric literals in different formats.
+- Handles numeric literals in different formats, distinguishing between integers and floating-point numbers.
 - Provides detailed error messages with line number, column number, and input snippet.
 - Categorizes errors into different types: syntax errors, invalid character errors, and unexpected end of input errors.
 - Includes unit tests to ensure correctness.
@@ -45,20 +45,17 @@ package main
 
 import (
     "fmt"
+    "strings"
     "github.com/Warashi/lispish/lexer"
 )
 
 func main() {
-    input := "(define (square x) (* x x))"
-    l := lexer.NewLexer(input)
+    input := "(define (square x) (* x x) 42 3.14)"
+    l := lexer.NewLexer(strings.NewReader(input))
 
     for {
-        tok, err := l.NextToken()
-        if err != nil {
-            fmt.Printf("Error: %v\n", err)
-            break
-        }
-        if tok.Type == lexer.EOF {
+        tok := l.NextToken()
+        if tok.Type == lexer.TokenEOF {
             break
         }
         fmt.Printf("Token: %+v\n", tok)

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -16,7 +16,8 @@ const (
 	TokenRParen      // )
 	TokenQuote       // '
 	TokenIdentifier  // 識別子
-	TokenNumber      // 数値（整数・浮動小数点）
+	TokenInteger     // 整数
+	TokenFloat       // 浮動小数点数
 	TokenString      // 文字列リテラル
 	TokenComment     // コメント
 )
@@ -34,8 +35,10 @@ func (t TokenType) String() string {
 		return "Quote"
 	case TokenIdentifier:
 		return "Identifier"
-	case TokenNumber:
-		return "Number"
+	case TokenInteger:
+		return "Integer"
+	case TokenFloat:
+		return "Float"
 	case TokenString:
 		return "String"
 	case TokenComment:
@@ -130,8 +133,10 @@ func (l *Lexer) NextToken() Token {
 				unquoted = text
 			}
 			return Token{Type: TokenString, Literal: unquoted}
-		case scanner.Int, scanner.Float:
-			return Token{Type: TokenNumber, Literal: text}
+		case scanner.Int:
+			return Token{Type: TokenInteger, Literal: text}
+		case scanner.Float:
+			return Token{Type: TokenFloat, Literal: text}
 		case scanner.Ident:
 			return Token{Type: TokenIdentifier, Literal: text}
 		default:

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -34,13 +34,37 @@ func TestLexer(t *testing.T) {
 		{Type: TokenRParen, Literal: ")"},
 		{Type: TokenQuote, Literal: "'"},
 		{Type: TokenLParen, Literal: "("},
-		{Type: TokenNumber, Literal: "1"},
-		{Type: TokenNumber, Literal: "2"},
+		{Type: TokenInteger, Literal: "1"},
+		{Type: TokenInteger, Literal: "2"},
 		{Type: TokenString, Literal: "three"},
-		{Type: TokenNumber, Literal: "4.0"},
+		{Type: TokenFloat, Literal: "4.0"},
 		{Type: TokenRParen, Literal: ")"},
 		{Type: TokenComment, Literal: "; コメント中のホワイトスペースを含む"},
 		{Type: TokenComment, Literal: "; コメント中の	タブを含む"},
+		{Type: TokenEOF, Literal: ""},
+	}
+
+	for i, expected := range expectedTokens {
+		token := lexer.NextToken()
+		if token.Type != expected.Type || token.Literal != expected.Literal {
+			t.Errorf("Token %d: expected (%s, %q), got (%s, %q)",
+				i, expected.Type, expected.Literal, token.Type, token.Literal)
+		}
+	}
+}
+
+func TestLexerWithAdditionalCases(t *testing.T) {
+	input := `
+123
+456.789
+`
+
+	lexer := NewLexer(strings.NewReader(input))
+
+	// 期待するトークン列
+	expectedTokens := []Token{
+		{Type: TokenInteger, Literal: "123"},
+		{Type: TokenFloat, Literal: "456.789"},
 		{Type: TokenEOF, Literal: ""},
 	}
 


### PR DESCRIPTION
Distinguish between integers and floating-point numbers in the lexer.

* **README.md**
  - Update the features section to mention the distinction between integers and floating-point numbers.
  - Update the example code to show how the lexer handles both integers and floating-point numbers.

* **lexer/lexer.go**
  - Split `TokenNumber` into `TokenInteger` and `TokenFloat` in the `TokenType` constants.
  - Update the `NextToken` function to return `TokenInteger` for `scanner.Int` and `TokenFloat` for `scanner.Float`.

* **lexer/lexer_test.go**
  - Update the `expectedTokens` slice to differentiate between integer and floating-point number tokens.
  - Add new test cases to cover scenarios with both integers and floating-point numbers.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Warashi/lispish/pull/14?shareId=50dc7182-5906-4e2f-aae8-317ad1ef4ad3).