### PR TITLE
Update Go version to 1.23.6

### DIFF
--- a/.github/workflows/go_tests.yml
+++ b/.github/workflows/go_tests.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: [1.23.4]
+        go-version: [1.23.6]
         os: [ubuntu-latest]
 
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/Warashi/lispish
 
-go 1.23.5
+go 1.23.6


### PR DESCRIPTION
Update the Go version to 1.23.6.

* **go.mod**
  - Update the Go version from 1.23.5 to 1.23.6.

* **.github/workflows/go_tests.yml**
  - Update the `go-version` matrix from 1.23.4 to 1.23.6.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Warashi/lispish/pull/16?shareId=1899ea31-72f0-46cc-9112-4e0c13286fde).